### PR TITLE
Add check-tickets workflow and README secret instructions

### DIFF
--- a/.github/workflows/check-tickets.yml
+++ b/.github/workflows/check-tickets.yml
@@ -1,0 +1,21 @@
+name: Check Melon Tickets
+
+on:
+  workflow_dispatch: {}
+  # schedule:
+  #   - cron: '*/5 * * * *'  # every 5 minutes
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check Tickets
+        uses: mooyoul/melon-ticket-actions@v1.1.0
+        with:
+          product-id: '204755'
+          schedule-id: '100001'
+          seat-id: '1_0'
+          slack-incoming-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          message: '<@U12345678> 有票啦~'

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ GitHub action that checks ticket availability in Melon Ticket (Korean online tic
 
 ## Usage
 
-Please see [example workflow](https://github.com/mooyoul/melon-ticket-actions/blob/1c5a56b9cdd594051d856c16b020f0c5835f6955/.github/workflows/example.yml), or [Workflow Log](https://github.com/mooyoul/melon-ticket-actions/actions?query=workflow%3Aexample) 
+Please see [example workflow](https://github.com/mooyoul/melon-ticket-actions/blob/1c5a56b9cdd594051d856c16b020f0c5835f6955/.github/workflows/example.yml), or [Workflow Log](https://github.com/mooyoul/melon-ticket-actions/actions?query=workflow%3Aexample)
+
+## Secrets
+
+This action sends notifications to Slack. Create a repository secret named `SLACK_WEBHOOK_URL`: Settings → Secrets and variables → Actions → New repository secret. Put your Slack incoming webhook URL there and the workflow will read it as `${{ secrets.SLACK_WEBHOOK_URL }}`.
 
 ## Sample Github Actions Configuration 
 


### PR DESCRIPTION
Why

This adds a manual workflow to run the melon-ticket-actions and documents how to configure the Slack webhook secret so the action can send notifications. Reviewers can quickly run the workflow and verify notifications without guessing repository settings.

What changed and approach

- Added `.github/workflows/check-tickets.yml` — a workflow that checks tickets using the published action `mooyoul/melon-ticket-actions@v1.1.0`. It includes a `workflow_dispatch` trigger so maintainers can run it manually for testing.
- Updated `README.md` — added a “Secrets” section describing how to create the `SLACK_WEBHOOK_URL` repository secret and how the workflow reads it as `${{ secrets.SLACK_WEBHOOK_URL }}`.

Notes and review guidance

- No behavior changes to action code; only CI/workflow and docs were added.
- Ensure a valid Slack incoming webhook URL is stored in `SLACK_WEBHOOK_URL` before running the workflow. If reviewers prefer a different secret name, mention it in comments.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>